### PR TITLE
fmtとlintをciで実行

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  push:
+    branches: [ main,develop ]
+  pull_request:
+    branches: [ main,develop ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run format check
+      run: npm run format:ci
+    - name: Run lint
+      run: npm run lint:ci

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "lint:precommit": "eslint './**/*.{ts,tsx}' --ignore-pattern 'src/utils/**' --max-warnings 0",
     "fmt:precommit": "prettier -l './**/*.{js,jsx,ts,tsx,json,css}'",
     "export": "next export",
-    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'"
+    "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",
+    "format:ci": "prettier -l './**/*.{js,jsx,ts,tsx,json,css}'",
+    "lint:ci": "eslint './**/*.{ts,tsx}' --ignore-pattern 'src/utils/**' --max-warnings 0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## 実装内容
   - github actionsでCI(継続的インテグレーション) フォーマットのチェックとeslintでの構文チェックを行う
## 関連issue
   - https://github.com/YukaChoco/project-who/issues/87
## 特にみて欲しい部分
pre-commitでゴミコードは弾いてるはずだけど、一応CIとしても実行する。
今後jestとかでtestが書けたらいいなー。
<img width="924" alt="image" src="https://github.com/YukaChoco/project-who/assets/79328014/ba1c52a4-877a-4a20-8bbd-cadce287ddc2">

## 未実装の部分

## 補足