### PR TITLE
firebaseのapikeyなどをenv.localに移動

### DIFF
--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,12 +1,7 @@
-// Import the functions you need from the SDKs you need
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
 
-// Your web app's Firebase configuration
-// For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_APIKEY,
   authDomain: process.env.NEXT_PUBLIC_AUTHDOMAIN,

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -8,13 +8,13 @@ import { getFirestore } from 'firebase/firestore';
 // Your web app's Firebase configuration
 // For Firebase JS SDK v7.20.0 and later, measurementId is optional
 const firebaseConfig = {
-  apiKey: 'AIzaSyCXmYcZaKGhoVVbPWRmR0QvebNgdLHbJz0',
-  authDomain: 'who-797e5.firebaseapp.com',
-  projectId: 'who-797e5',
-  storageBucket: 'who-797e5.appspot.com',
-  messagingSenderId: '792930996511',
-  appId: '1:792930996511:web:1213c25af7f44a0a32a02a',
-  measurementId: 'G-TJEEGY3EE4',
+  apiKey: process.env.NEXT_PUBLIC_APIKEY,
+  authDomain: process.env.NEXT_PUBLIC_AUTHDOMAIN,
+  projectId: process.env.NEXT_PUBLIC_PROJECTID,
+  storageBucket: process.env.NEXT_PUBLIC_STORAGEBUCKET,
+  messagingSenderId: process.env.NEXT_PUBLIC_MESSAGINGSENDERID,
+  appId: process.env.NEXT_PUBLIC_APPID,
+  measurementId: process.env.NEXT_PUBLIC_MEASUREMENTID,
 };
 
 // Initialize Firebase


### PR DESCRIPTION
## 実装内容
   - Firebase関連の秘匿情報を`.env.local`に移動
## 関連issue
   - #91 
## 特にみて欲しい部分
   - Firebaseのwebアプリケーション事態を再作成したが、秘匿情報部分の再発行方法として正しいのか。
## 未実装の部分

## 補足
   - 元のアプリ情報は30日後に削除される予定です
　(PRが通ってデプロイ先まで反映されるまで動かなくなってしまうのを防ぐため)
   - PRが認証されたタイミングでメンバーにSlackを通してenvファイルの詳細を通達します