### PR TITLE
windowsが認識できるようにクオーテーションの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "npx husky install",
     "lint": "next lint",
     "lint-fix": "next lint --fix",
-    "lint:precommit": "eslint './**/*.{ts,tsx}' --ignore-pattern 'src/utils/**' --max-warnings 0",
+    "lint:precommit": "eslint \"./**/*.{ts,tsx}\" --ignore-pattern \"src/utils/**\" --max-warnings 0",
     "fmt:precommit": "prettier -l './**/*.{js,jsx,ts,tsx,json,css}'",
     "export": "next export",
     "format": "prettier --write --ignore-path .gitignore './**/*.{js,jsx,ts,tsx,json,css}'",


### PR DESCRIPTION
## 実装内容
   - lintのprecommitのシングルクオーテーションを`/"`に修正
## 関連issue
   - #106
## 特にみて欲しい部分
   - Macでもコミットができるか
## 未実装の部分

## 補足