### PR TITLE
 qrcodeに表示するURLを環境依存にする

### DIFF
--- a/src/pages/share.tsx
+++ b/src/pages/share.tsx
@@ -74,7 +74,7 @@ export default function Detail() {
         <div className={styles.list}>
           <Header useMenuIcon />
           <div className={styles.qrcode}>
-            <QRCode url={`https://project-who.vercel.app/card/${cardData[0].id}`} />
+            <QRCode url={`${window.location.origin}/card/${cardData[0].id}`} />
           </div>
           <Box sx={{ width: '100%' }}>{display}</Box>
         </div>


### PR DESCRIPTION
## 実装内容
   - qrcodeに表示するURLを環境依存で変わるようにした
## 関連issue
   - https://github.com/YukaChoco/project-who/issues/124
## 特にみて欲しい部分

## 未実装の部分

## 補足
firebaseの関数のせいでエラー出てるけど直してません。
hooksにするときに同時に直してください
<img width="962" alt="image" src="https://github.com/YukaChoco/project-who/assets/79328014/28c3c7c4-8299-41b0-87bf-b1c42dabe4f8">
