### PR TITLE
cardのstate更新中もLoadingとする

### DIFF
--- a/src/pages/share.tsx
+++ b/src/pages/share.tsx
@@ -15,6 +15,7 @@ import getMyCardDetailsByUserId from '@/utils/ok/getMyCardDetailsByUserId';
 export default function Detail() {
   const [cardData, setCardDatas] = useState<CardData[] | null>([]);
   const { userId, loading } = useUser();
+  const isSettingCard = cardData?.length === 0;
   useEffect(() => {
     const fetchCards = async () => {
       if (userId) {
@@ -25,7 +26,7 @@ export default function Detail() {
     fetchCards();
   }, [userId]);
 
-  if (loading) {
+  if (loading || isSettingCard) {
     return (
       <>
         <Head>


### PR DESCRIPTION
## 実装内容
   - `share.tsx`のloadingに`card.length===0`を追加した
## 関連issue
   - #125
## 特にみて欲しい部分

## 未実装の部分
   - loadingを複数持ってしまっている。
   - 後にuseCardなどにまとめた際に改めて修正する。
## 補足
   - https://github.com/YukaChoco/project-who/pull/123#issue-2002443934 の補足にあった関数に問題があるというのは、おそらくuseStateの更新に問題があるかと思います。
   - customHooksにまとめる際に根本的なエラー解決をする予定です。