### PR TITLE
共有画面へのリンクを増やす

### DIFF
--- a/src/pages/card/[cardid].tsx
+++ b/src/pages/card/[cardid].tsx
@@ -5,8 +5,8 @@ import { useEffect, useState } from 'react';
 import Card from '@/components/Card';
 import DisplayText from '@/components/DisplayText';
 import Header from '@/components/Header';
+import PrimaryButton from '@/components/PrimaryButton';
 import SecondaryButton from '@/components/SecondaryButton';
-import ShareButton from '@/components/ShareButton';
 import useUser from '@/hooks/useUser';
 import styles from '@/styles/CardDetail.module.css';
 import type { CardData } from '@/types/CardData';
@@ -62,7 +62,18 @@ export default function Index() {
   const showButtons = () => {
     if (cardData?.authorId === userId) {
       // 名刺作成者
-      return <SecondaryButton text='この名刺を編集する' onClick={() => router.push(`/edit/${cardType}?cardId=${cardId}`)} />;
+      return (
+        <>
+          <Box sx={{ margin: '15px 0px' }}>
+            <PrimaryButton text='この名刺を編集する' onClick={() => router.push(`/edit/${cardType}?cardId=${cardId}`)} />
+          </Box>
+          {cardType === CardType.My && (
+            <Box sx={{ margin: '15px 0px' }}>
+              <SecondaryButton text='この名刺を共有する' onClick={() => router.push(`/share?cardId=${cardId}`)} />
+            </Box>
+          )}
+        </>
+      );
     } else if (cardType === CardType.Have) {
       // カード登録済みのユーザ
       return <SecondaryButton text='登録済み' disabled />;
@@ -131,8 +142,6 @@ export default function Index() {
           </div>
 
           <div className={styles.container}>{showButtons()}</div>
-
-          <ShareButton />
         </main>
       </>
     );

--- a/src/pages/cards.tsx
+++ b/src/pages/cards.tsx
@@ -51,23 +51,6 @@ export default function Index() {
     );
   }
 
-  if (!cardDatas) {
-    return (
-      <main>
-        <>
-          <Header useMenuIcon />
-          <h1>自分の名刺がありません</h1>
-
-          <SecondaryButton text='自分の名刺を作成する' onClick={() => router.push('/make/mycard')} />
-        </>
-      </main>
-    );
-  }
-
-  const display = cardDatas.map((data) => {
-    return <DisplayCard urlEnabled={false} key={data.id} {...data} link={`/card/${data.id}`} />;
-  });
-
   return (
     <>
       <Head>
@@ -76,8 +59,20 @@ export default function Index() {
 
       <main>
         <Header useMenuIcon />
-
-        <div className={styles.cardlist}>{display}</div>
+        {cardDatas ? (
+          // 名刺が存在する時
+          <div className={styles.cardlist}>
+            {cardDatas.map((data) => {
+              return <DisplayCard urlEnabled={false} key={data.id} {...data} link={`/card/${data.id}`} />;
+            })}
+          </div>
+        ) : (
+          // 名刺が存在しない時
+          <>
+            <h1>自分の名刺がありません</h1>
+            <SecondaryButton text='自分の名刺を作成する' onClick={() => router.push('/make/mycard')} />
+          </>
+        )}
 
         <ShareButton />
       </main>

--- a/src/pages/cards.tsx
+++ b/src/pages/cards.tsx
@@ -68,10 +68,7 @@ export default function Index() {
           </div>
         ) : (
           // 名刺が存在しない時
-          <>
-            <h1>自分の名刺がありません</h1>
-            <SecondaryButton text='自分の名刺を作成する' onClick={() => router.push('/make/mycard')} />
-          </>
+          <h1>登録された名刺がありません</h1>
         )}
 
         <ShareButton />

--- a/src/pages/mycards.tsx
+++ b/src/pages/mycards.tsx
@@ -6,6 +6,7 @@ import Header from '@/components/Header';
 import NewCard from '@/components/NewCard';
 import PrimaryButton from '@/components/PrimaryButton';
 import SecondaryButton from '@/components/SecondaryButton';
+import ShareButton from '@/components/ShareButton';
 import useUser from '@/hooks/useUser';
 import styles from '@/styles/Mycards.module.css';
 import { CardData } from '@/types/CardData';
@@ -70,6 +71,8 @@ export default function Index() {
         <div className={styles.returnHomeButton}>
           <PrimaryButton text={'ホームに戻る'} onClick={() => router.push('/cards')} />
         </div>
+
+        <ShareButton />
       </main>
     </>
   );

--- a/src/styles/Mycards.module.css
+++ b/src/styles/Mycards.module.css
@@ -15,10 +15,6 @@
 }
 
 .returnHomeButton {
-  margin-bottom: 20px;
   width: 100%;
-  position: fixed;
-  padding: 0px 20px;
-  left: 0px;
-  bottom: 0px;
+  margin-top: 60px;
 }


### PR DESCRIPTION
## 実装内容
   - `cards.tsx`内のログインユーザのreturnを統一し、常に`Head`タグや`ShareButton`が適応されるようにした
   - `mycards.tsx`にも`ShareButton`を追加した
   - 名刺詳細画面にて自分の名刺であった場合に「この名刺を共有する」ボタンを追加した(共有画面へ飛ばされる)
## 関連issue
   - #127 
## 特にみて欲しい部分

## 未実装の部分
- 共有画面へのリンクで`cardId`というクエリを渡しているが、共有画面ではcardDatas[0]が共有されるようになっている
## 補足