### PR TITLE
bashのtextareaになってると、リンクがテキスト判定されたり面倒なので変更

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_issue.yml
+++ b/.github/ISSUE_TEMPLATE/new_issue.yml
@@ -18,7 +18,6 @@ body:
         2.
         3.
         ...
-      render: bash
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## 実装内容
   - issue-templateのissueの作成の必要な作業内容が、bashのtextareaになってると、リンクがテキスト判定されたり面倒なので変更
## 関連issue
   - https://github.com/YukaChoco/project-who/issues/137
## 特にみて欲しい部分

## 未実装の部分

## 補足
このようになっていると、リンクを貼っても押せないので、普通のテキストエリアにしました。
<img width="928" alt="image" src="https://github.com/YukaChoco/project-who/assets/79328014/058bc2a8-29a3-47b4-9535-714e59ded982">
